### PR TITLE
[FEAT] Member 도메인 설계 및 영속 레포지토리 구현

### DIFF
--- a/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/SecurityFilterChainConfig.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/SecurityFilterChainConfig.java
@@ -1,7 +1,7 @@
 package com.fisa.auth.security;
 
-import com.fisa.bank.common.config.security.resource.RequiredAuthenticationEntryPoint;
-import com.fisa.bank.common.config.security.resource.UnknownEndPointFilter;
+import com.fisa.auth.security.resource.RequiredAuthenticationEntryPoint;
+import com.fisa.auth.security.resource.UnknownEndPointFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;

--- a/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/authorization/RegistrarInitializer.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/authorization/RegistrarInitializer.java
@@ -1,7 +1,7 @@
 package com.fisa.auth.security.authorization;
 
-import static com.fisa.bank.common.config.security.authorization.OAuth2Const.SCOPE_CLIENT_CREATE;
-import static com.fisa.bank.common.config.security.authorization.OAuth2Const.SCOPE_CLIENT_READ;
+import static com.fisa.auth.security.authorization.OAuth2Const.SCOPE_CLIENT_CREATE;
+import static com.fisa.auth.security.authorization.OAuth2Const.SCOPE_CLIENT_READ;
 
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;

--- a/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/jwt/UserJwtGenerator.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/jwt/UserJwtGenerator.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Collection;
+import java.util.UUID;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.security.oauth2.jwt.JwsHeader;
@@ -31,11 +32,11 @@ public class UserJwtGenerator {
     this.jwtProperties = jwtProperties;
   }
 
-  public Jwt createAccessToken(Long userId, Collection<? extends GrantedAuthority> authorities) {
+  public Jwt createAccessToken(UUID memberId, Collection<? extends GrantedAuthority> authorities) {
     ZonedDateTime now = LocalDateTime.now().atZone(KST);
     JwtClaimsSet claimsSet =
         JwtClaimsSet.builder()
-            .claim(CLAIM_USER_ID, userId)
+            .claim(CLAIM_USER_ID, memberId)
             .claim(CLAIM_ROLE, authorities)
             .issuer(CLAIM_ISSUER)
             .issuedAt(now.toInstant())
@@ -45,11 +46,11 @@ public class UserJwtGenerator {
     return jwtEncoder.encode(JwtEncoderParameters.from(header, claimsSet));
   }
 
-  public Jwt createRefreshToken(Long userId) {
+  public Jwt createRefreshToken(UUID memberId) {
     ZonedDateTime now = LocalDateTime.now().atZone(KST);
     JwtClaimsSet claimsSet =
         JwtClaimsSet.builder()
-            .claim(CLAIM_USER_ID, userId)
+            .claim(CLAIM_USER_ID, memberId)
             .issuer(CLAIM_ISSUER)
             .issuedAt(now.toInstant())
             .expiresAt(now.toInstant().plus(jwtProperties.getRefreshTokenExpiration()))

--- a/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/mock/TestLoginSuccessHandler.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/mock/TestLoginSuccessHandler.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -42,7 +43,7 @@ public class TestLoginSuccessHandler implements AuthenticationSuccessHandler {
 
       if (Objects.nonNull(user)) {
 
-        Long userId = Long.valueOf(user.getUsername());
+        UUID userId = UUID.fromString(user.getUsername());
 
         Collection<? extends GrantedAuthority> authorities = user.getAuthorities();
         String accessToken = jwtGenerator.createAccessToken(userId, authorities).getTokenValue();

--- a/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/mock/TestLoginSuccessHandler.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/mock/TestLoginSuccessHandler.java
@@ -43,7 +43,7 @@ public class TestLoginSuccessHandler implements AuthenticationSuccessHandler {
 
       if (Objects.nonNull(user)) {
 
-        UUID userId = UUID.fromString(user.getUsername());
+        UUID userId = UUID.fromString(user.getUsername()); // UUID ?
 
         Collection<? extends GrantedAuthority> authorities = user.getAuthorities();
         String accessToken = jwtGenerator.createAccessToken(userId, authorities).getTokenValue();

--- a/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/mock/TestUserDetailsService.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/mock/TestUserDetailsService.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 public class TestUserDetailsService implements UserDetailsService {
 
   @Override
-  public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
-    return new User(userId, "{noop}password", Collections.emptyList());
+  public UserDetails loadUserByUsername(String memberId) throws UsernameNotFoundException {
+    return new User(memberId, "{noop}password", Collections.emptyList());
   }
 }

--- a/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/mock/TestUsernamePasswordAuthenticationConverter.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/mock/TestUsernamePasswordAuthenticationConverter.java
@@ -14,9 +14,9 @@ public class TestUsernamePasswordAuthenticationConverter implements Authenticati
   @Override
   public Authentication convert(HttpServletRequest request) {
     try {
-      String userId = request.getRequestURI().replace("/api/login/", "");
+      String memberId = request.getRequestURI().replace("/api/login/", "");
 
-      return new UsernamePasswordAuthenticationToken(userId, "{noop}password");
+      return new UsernamePasswordAuthenticationToken(memberId, "{noop}password");
     } catch (Exception e) {
       throw new AuthenticationServiceException(
           "Failed to create UsernamePasswordAuthentication", e);

--- a/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/mock/TestUsernamePasswordAuthenticationProvider.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/mock/TestUsernamePasswordAuthenticationProvider.java
@@ -12,12 +12,12 @@ public class TestUsernamePasswordAuthenticationProvider implements Authenticatio
 
   @Override
   public Authentication authenticate(Authentication authentication) throws AuthenticationException {
-    String userId = (String) authentication.getPrincipal();
+    String memberId = (String) authentication.getPrincipal();
     String password = (String) authentication.getCredentials();
     Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
 
     return new UsernamePasswordAuthenticationToken(
-        new User(userId, password, authorities), password, authorities);
+        new User(memberId, password, authorities), password, authorities);
   }
 
   @Override

--- a/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/resource/AuthorizationConfig.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/resource/AuthorizationConfig.java
@@ -2,6 +2,7 @@ package com.fisa.auth.security.resource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fisa.auth.security.jwt.UserJwtGenerator;
+import com.fisa.member.application.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -79,8 +80,8 @@ public class AuthorizationConfig {
   }
 
   @Bean("UserDetailsService")
-  public UserDetailsService userDetailsService(UserAuthRepository userAuthRepository) {
-    return new CustomUserDetailsService(userAuthRepository);
+  public UserDetailsService userDetailsService(MemberRepository memberRepository) {
+    return new CustomUserDetailsService(memberRepository);
   }
 
   @Bean("BcryptPasswordEncoder")
@@ -101,9 +102,9 @@ public class AuthorizationConfig {
   @Bean("LoginSuccessHandler")
   public AuthenticationSuccessHandler loginSuccessHandler(
       ObjectMapper objectMapper,
-      UserAuthRepository userAuthRepository,
+      MemberRepository memberRepository,
       UserJwtGenerator jwtGenerator) {
-    return new LoginSuccessHandler(jwtGenerator, objectMapper, userAuthRepository);
+    return new LoginSuccessHandler(jwtGenerator, objectMapper, memberRepository);
   }
 
   @Bean("UsernamePasswordAuthenticationConverter")

--- a/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/resource/CustomUserDetails.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/resource/CustomUserDetails.java
@@ -1,6 +1,6 @@
 package com.fisa.auth.security.resource;
 
-import com.fisa.bank.user.persistence.entity.id.UserId;
+import com.fisa.member.application.model.MemberId;
 import java.util.Collection;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +10,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 @Getter
 @RequiredArgsConstructor
 public final class CustomUserDetails implements UserDetails {
-  private final UserId userId; // ← 도메인 식별자
+  private final MemberId memberId; // ← 도메인 식별자
   private final String username;
   private final String password;
   private final Collection<? extends GrantedAuthority> authorities;

--- a/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/resource/CustomUserDetailsService.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/auth/security/resource/CustomUserDetailsService.java
@@ -1,7 +1,9 @@
 package com.fisa.auth.security.resource;
 
-import com.fisa.bank.user.persistence.entity.UserAuth;
-import com.fisa.bank.user.persistence.repository.UserAuthRepository;
+import com.fisa.member.application.model.Member;
+import com.fisa.member.application.model.auth.AuthInfo;
+import com.fisa.member.application.model.auth.LoginId;
+import com.fisa.member.application.repository.MemberRepository;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.User;
@@ -12,19 +14,14 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
-  private final UserAuthRepository authRepository;
+  private final MemberRepository memberRepository;
 
   @Override
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 
-    UserAuth userAuth =
-        authRepository
-            .findById(username)
-            .orElseThrow(
-                () ->
-                    new UsernameNotFoundException(
-                        String.format("Username not found : %s", username)));
+    Member member = memberRepository.findByLoginId(LoginId.of(username));
+    AuthInfo authInfo = member.getAuthInfo();
 
-    return new User(username, userAuth.getPassword(), Collections.emptyList());
+    return new User(username, authInfo.getCredential().getValue(), Collections.emptyList());
   }
 }

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/dto/MemberCreateCommand.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/dto/MemberCreateCommand.java
@@ -1,0 +1,18 @@
+package com.fisa.member.application.dto;
+
+import com.fisa.member.application.model.auth.AuthInfo;
+import com.fisa.member.application.model.profile.Curriculum;
+import com.fisa.member.application.model.profile.Email;
+import com.fisa.member.application.model.profile.MemberName;
+import com.fisa.member.application.model.profile.PhoneNumber;
+
+public record MemberCreateCommand(
+        String name,
+        String phoneNumber,
+        String email,
+        String curriculum,
+        String loginId,
+        String credential,
+        int generation
+) {
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/Member.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/Member.java
@@ -1,0 +1,52 @@
+package com.fisa.member.application.model;
+
+import com.fisa.member.application.model.auth.AuthInfo;
+import com.fisa.member.application.model.profile.Curriculum;
+import com.fisa.member.application.model.profile.Email;
+import com.fisa.member.application.model.profile.MemberName;
+import com.fisa.member.application.model.profile.PhoneNumber;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Member {
+
+    private final MemberId id;
+    private final MemberName name;
+    private final PhoneNumber phoneNumber;
+    private final Integer generation;
+    private final Email email;
+    private final Curriculum curriculum;
+    private final AuthInfo authInfo;
+
+    @Builder
+    private Member(
+                   MemberId id,
+                   MemberName name,
+                   PhoneNumber phoneNumber,
+                   Integer generation,
+                   Email email,
+                   Curriculum curriculum,
+                   AuthInfo authInfo){
+        this.id = id;
+        this.curriculum = curriculum;
+        this.phoneNumber = phoneNumber;
+        this.generation = generation;
+        this.email = email;
+        this.name = name;
+        this.authInfo = authInfo;
+    }
+
+    public static Member create(String name, String phoneNumber, int generation, String email, String curriculum, String loginId, String credential){
+        return Member.builder()
+                .id(MemberId.createNew())
+                .curriculum(Curriculum.findByEnumName(curriculum))
+                .email(Email.of(email))
+                .phoneNumber(PhoneNumber.of(phoneNumber))
+                .generation(generation)
+                .name(MemberName.of(name))
+                .authInfo(AuthInfo.create(loginId, credential))
+                .build();
+    }
+
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/Member.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/Member.java
@@ -5,6 +5,8 @@ import com.fisa.member.application.model.profile.Curriculum;
 import com.fisa.member.application.model.profile.Email;
 import com.fisa.member.application.model.profile.MemberName;
 import com.fisa.member.application.model.profile.PhoneNumber;
+import java.util.UUID;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -19,7 +21,7 @@ public class Member {
     private final Curriculum curriculum;
     private final AuthInfo authInfo;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Member(
                    MemberId id,
                    MemberName name,
@@ -35,6 +37,18 @@ public class Member {
         this.email = email;
         this.name = name;
         this.authInfo = authInfo;
+    }
+
+    public static Member load(UUID memberId, String name, String phoneNumber, int generation, String email, Curriculum curriculum, String loginId, String credential){
+        return Member.builder()
+                .authInfo(AuthInfo.create(loginId, credential))
+                .id(MemberId.load(memberId))
+                .phoneNumber(PhoneNumber.of(phoneNumber))
+                .generation(generation)
+                .email(Email.of(email))
+                .name(MemberName.of(name))
+                .curriculum(curriculum)
+                .build();
     }
 
     public static Member create(String name, String phoneNumber, int generation, String email, String curriculum, String loginId, String credential){

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/MemberId.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/MemberId.java
@@ -1,0 +1,27 @@
+package com.fisa.member.application.model;
+
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class MemberId {
+
+    private final UUID id;
+
+    private MemberId(String uuid){
+        this.id = UUID.fromString(uuid);
+    }
+
+    private MemberId(){
+        this.id = UUID.randomUUID();
+    }
+
+    public static MemberId createNew(){
+        return new MemberId();
+    }
+
+    public static MemberId load(String uuid){
+        return new MemberId(uuid);
+    }
+
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/MemberId.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/MemberId.java
@@ -6,14 +6,14 @@ import lombok.Getter;
 @Getter
 public class MemberId {
 
-    private final UUID id;
+    private final UUID value;
 
     private MemberId(UUID uuid){
-        this.id = uuid;
+        this.value = uuid;
     }
 
     private MemberId(){
-        this.id = UUID.randomUUID();
+        this.value = UUID.randomUUID();
     }
 
     public static MemberId createNew(){

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/MemberId.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/MemberId.java
@@ -8,8 +8,8 @@ public class MemberId {
 
     private final UUID id;
 
-    private MemberId(String uuid){
-        this.id = UUID.fromString(uuid);
+    private MemberId(UUID uuid){
+        this.id = uuid;
     }
 
     private MemberId(){
@@ -20,7 +20,7 @@ public class MemberId {
         return new MemberId();
     }
 
-    public static MemberId load(String uuid){
+    public static MemberId load(UUID uuid){
         return new MemberId(uuid);
     }
 

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/auth/AuthInfo.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/auth/AuthInfo.java
@@ -1,0 +1,27 @@
+package com.fisa.member.application.model.auth;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AuthInfo {
+
+    private final LoginId loginId;
+    private final Credential credential;
+
+    @Builder
+    private AuthInfo(LoginId loginId,
+                    Credential credential){
+        this.credential = credential;
+        this.loginId = loginId;
+    }
+
+    public static AuthInfo create(String loginId, String credential){
+        return AuthInfo.builder()
+                .credential(Credential.of(credential))
+                .loginId(LoginId.of(loginId))
+                .build();
+    }
+
+
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/auth/AuthInfo.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/auth/AuthInfo.java
@@ -1,5 +1,6 @@
 package com.fisa.member.application.model.auth;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,7 +10,7 @@ public class AuthInfo {
     private final LoginId loginId;
     private final Credential credential;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private AuthInfo(LoginId loginId,
                     Credential credential){
         this.credential = credential;

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/auth/Credential.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/auth/Credential.java
@@ -7,11 +7,11 @@ public class Credential {
 
     private static final String REGEX = "";
 
-    private final String credential;
+    private final String value;
 
     private Credential(String credential){
         validate(credential);
-        this.credential = credential;
+        this.value = credential;
     }
 
     private void validate(String credential) {

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/auth/Credential.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/auth/Credential.java
@@ -1,0 +1,25 @@
+package com.fisa.member.application.model.auth;
+
+import lombok.Getter;
+
+@Getter
+public class Credential {
+
+    private static final String REGEX = "";
+
+    private final String credential;
+
+    private Credential(String credential){
+        validate(credential);
+        this.credential = credential;
+    }
+
+    private void validate(String credential) {
+
+    }
+
+    public static Credential of(String credential){
+        return new Credential(credential);
+    }
+
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/auth/LoginId.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/auth/LoginId.java
@@ -1,0 +1,25 @@
+package com.fisa.member.application.model.auth;
+
+import lombok.Getter;
+
+@Getter
+public class LoginId {
+
+    private final String REGEX = "";
+
+    private final String loginId;
+
+    private LoginId(String loginId){
+        validate(loginId);
+        this.loginId = loginId;
+    }
+
+    private void validate(String loginId) {
+
+    }
+
+    public static LoginId of(String loginId){
+        return new LoginId(loginId);
+    }
+
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/auth/LoginId.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/auth/LoginId.java
@@ -7,11 +7,11 @@ public class LoginId {
 
     private final String REGEX = "";
 
-    private final String loginId;
+    private final String value;
 
     private LoginId(String loginId){
         validate(loginId);
-        this.loginId = loginId;
+        this.value = loginId;
     }
 
     private void validate(String loginId) {

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/profile/Curriculum.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/profile/Curriculum.java
@@ -1,0 +1,25 @@
+package com.fisa.member.application.model.profile;
+
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Curriculum {
+
+    CLOUD_SERVICE_DEV("클라우드 서비스 개발반", "Cloud Service Development"),
+    CLOUD_ENGINEERING("클라우드 엔지니어링반", "Cloud Engineering"),
+    AI_ENGINEERING("AI 엔지니어링", "AI Engineering");
+
+    private final String koName;
+    private final String enName;
+
+    public static Curriculum findByEnumName(String enumName){
+        return Arrays.stream(Curriculum.values())
+                .filter(e -> e.name().equals(enumName))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("교육과정을 찾을 수 없습니다."));
+    }
+
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/profile/Email.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/profile/Email.java
@@ -7,11 +7,11 @@ public class Email {
 
     private static final String REGEX = "";
 
-    public final String email;
+    private final String value;
 
     private Email(String email){
         validate(email);
-        this.email = email;
+        this.value = email;
     }
 
     private void validate(String email) {

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/profile/Email.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/profile/Email.java
@@ -1,0 +1,24 @@
+package com.fisa.member.application.model.profile;
+
+import lombok.Getter;
+
+@Getter
+public class Email {
+
+    private static final String REGEX = "";
+
+    public final String email;
+
+    private Email(String email){
+        validate(email);
+        this.email = email;
+    }
+
+    private void validate(String email) {
+    }
+
+    public static Email of(String email){
+        return new Email(email);
+    }
+
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/profile/MemberName.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/profile/MemberName.java
@@ -5,10 +5,10 @@ import lombok.Getter;
 @Getter
 public class MemberName {
 
-    private final String name;
+    private final String value;
 
     private MemberName(String name){
-        this.name = name;
+        this.value = name;
     }
 
     public static MemberName of(String name){

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/profile/MemberName.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/profile/MemberName.java
@@ -1,0 +1,18 @@
+package com.fisa.member.application.model.profile;
+
+import lombok.Getter;
+
+@Getter
+public class MemberName {
+
+    private final String name;
+
+    private MemberName(String name){
+        this.name = name;
+    }
+
+    public static MemberName of(String name){
+        return new MemberName(name);
+    }
+
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/profile/PhoneNumber.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/profile/PhoneNumber.java
@@ -1,0 +1,24 @@
+package com.fisa.member.application.model.profile;
+
+import lombok.Getter;
+
+@Getter
+public class PhoneNumber {
+
+    private static final String REGEX = "";
+
+    private final String phoneNumber;
+
+    public PhoneNumber(String phoneNumber){
+        validate(phoneNumber);
+        this.phoneNumber = phoneNumber;
+    }
+
+    private void validate(String phoneNumber) {
+    }
+
+    public static PhoneNumber of(String phoneNumber){
+        return new PhoneNumber(phoneNumber);
+    }
+
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/profile/PhoneNumber.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/model/profile/PhoneNumber.java
@@ -7,11 +7,11 @@ public class PhoneNumber {
 
     private static final String REGEX = "";
 
-    private final String phoneNumber;
+    private final String value;
 
     public PhoneNumber(String phoneNumber){
         validate(phoneNumber);
-        this.phoneNumber = phoneNumber;
+        this.value = phoneNumber;
     }
 
     private void validate(String phoneNumber) {

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/repository/MemberRepository.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/repository/MemberRepository.java
@@ -4,15 +4,16 @@ import com.fisa.member.application.model.Member;
 import com.fisa.member.application.model.MemberId;
 import com.fisa.member.application.model.auth.LoginId;
 import com.fisa.member.application.model.profile.MemberName;
+import java.util.List;
 
 public interface MemberRepository {
 
-    Member findByName(MemberName name);
+    List<Member> findByName(MemberName name);
 
     Member findById(MemberId id);
 
     Member findByLoginId(LoginId loginId);
 
-
+    void save(Member member);
 
 }

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/repository/MemberRepository.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/repository/MemberRepository.java
@@ -1,0 +1,18 @@
+package com.fisa.member.application.repository;
+
+import com.fisa.member.application.model.Member;
+import com.fisa.member.application.model.MemberId;
+import com.fisa.member.application.model.auth.LoginId;
+import com.fisa.member.application.model.profile.MemberName;
+
+public interface MemberRepository {
+
+    Member findByName(MemberName name);
+
+    Member findById(MemberId id);
+
+    Member findByLoginId(LoginId loginId);
+
+
+
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/service/MemberCommandService.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/service/MemberCommandService.java
@@ -1,0 +1,41 @@
+package com.fisa.member.application.service;
+
+import com.fisa.member.application.dto.MemberCreateCommand;
+import com.fisa.member.application.model.Member;
+import com.fisa.member.application.repository.MemberRepository;
+import com.fisa.member.application.usecase.MemberCommandUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberCommandService implements MemberCommandUseCase {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public Member signUp(MemberCreateCommand command) {
+        try{
+            Member member = createNewMember(command);
+            
+            memberRepository.save(member);
+            
+            return member;
+        } catch (DataIntegrityViolationException e){
+            throw new IllegalArgumentException("UnAvailable Login Id");
+        }
+    }
+
+    private Member createNewMember(MemberCreateCommand command){
+        return Member.create(
+                command.name(),
+                command.phoneNumber(),
+                command.generation(),
+                command.email(),
+                command.curriculum(),
+                command.loginId(),
+                command.credential()
+        ) ;
+    }
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/service/MemberQueryService.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/service/MemberQueryService.java
@@ -1,0 +1,33 @@
+package com.fisa.member.application.service;
+
+import com.fisa.member.application.model.Member;
+import com.fisa.member.application.model.MemberId;
+import com.fisa.member.application.model.auth.LoginId;
+import com.fisa.member.application.model.profile.MemberName;
+import com.fisa.member.application.repository.MemberRepository;
+import com.fisa.member.application.usecase.MemberQueryUseCase;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberQueryService implements MemberQueryUseCase {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public List<Member> getByName(MemberName name) {
+        return List.of();
+    }
+
+    @Override
+    public Member getById(MemberId id) {
+        return null;
+    }
+
+    @Override
+    public Member getByLoginId(LoginId loginId) {
+        return null;
+    }
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/usecase/MemberCommandUseCase.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/usecase/MemberCommandUseCase.java
@@ -1,0 +1,10 @@
+package com.fisa.member.application.usecase;
+
+import com.fisa.member.application.dto.MemberCreateCommand;
+import com.fisa.member.application.model.Member;
+
+public interface MemberCommandUseCase {
+
+    Member signUp(MemberCreateCommand command);
+
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/application/usecase/MemberQueryUseCase.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/application/usecase/MemberQueryUseCase.java
@@ -1,0 +1,17 @@
+package com.fisa.member.application.usecase;
+
+import com.fisa.member.application.model.Member;
+import com.fisa.member.application.model.MemberId;
+import com.fisa.member.application.model.auth.LoginId;
+import com.fisa.member.application.model.profile.MemberName;
+import java.util.List;
+
+public interface MemberQueryUseCase {
+
+    List<Member> getByName(MemberName name);
+
+    Member getById(MemberId id);
+
+    Member getByLoginId(LoginId loginId);
+
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/entity/JpaAuthInfo.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/entity/JpaAuthInfo.java
@@ -1,0 +1,43 @@
+package com.fisa.member.persistence.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PRIVATE)
+public class JpaAuthInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String loginId;
+
+    private String credential;
+
+    @JoinColumn(nullable = false, name = "member_id")
+    @OneToOne(fetch = FetchType.EAGER)
+    private JpaMember member;
+
+    public static JpaAuthInfo of(String loginId, String credential){
+        return JpaAuthInfo.builder()
+                .loginId(loginId)
+                .credential(credential)
+                .build();
+    }
+
+
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/entity/JpaAuthInfo.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/entity/JpaAuthInfo.java
@@ -28,7 +28,6 @@ public class JpaAuthInfo {
 
     private String credential;
 
-    @JoinColumn(nullable = false, name = "member_id")
     @OneToOne(fetch = FetchType.EAGER)
     private JpaMember member;
 

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/entity/JpaAuthInfo.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/entity/JpaAuthInfo.java
@@ -1,12 +1,15 @@
 package com.fisa.member.persistence.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,14 +21,22 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder(access = AccessLevel.PRIVATE)
+@Table(
+        name = "member_auth_info",
+        indexes = {
+                @Index(name = "idx_member_auth_info", columnList = "login_id")
+        }
+)
 public class JpaAuthInfo {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, unique = true)
     private String loginId;
 
+    @Column(nullable = false)
     private String credential;
 
     @OneToOne(fetch = FetchType.EAGER)

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/entity/JpaMember.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/entity/JpaMember.java
@@ -1,0 +1,60 @@
+package com.fisa.member.persistence.entity;
+
+import com.fisa.member.application.model.profile.Curriculum;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PRIVATE)
+public class JpaMember {
+
+    @Id
+    private UUID id;
+
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private int generation;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Curriculum curriculum;
+
+    @OneToOne(fetch = FetchType.EAGER, mappedBy = "member")
+    private JpaAuthInfo authInfo;
+
+    public static JpaMember of(UUID id, String name, String phoneNumber, String email, Curriculum curriculum, int generation, String loginId, String credential){
+        return JpaMember.builder()
+                .authInfo(JpaAuthInfo.of(loginId, credential))
+                .email(email)
+                .curriculum(curriculum)
+                .generation(generation)
+                .phoneNumber(phoneNumber)
+                .name(name)
+                .id(id)
+                .build();
+    }
+
+
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/entity/JpaMember.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/entity/JpaMember.java
@@ -7,8 +7,10 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -21,6 +23,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder(access = AccessLevel.PRIVATE)
+@Table(
+        name = "member",
+        indexes = {
+                @Index(name = "idx_member_name", columnList = "name"),
+                @Index(name = "idx_member_email", columnList = "email")
+        }
+)
 public class JpaMember {
 
     @Id

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/entity/JpaMember.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/entity/JpaMember.java
@@ -7,6 +7,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -42,6 +43,7 @@ public class JpaMember {
     private Curriculum curriculum;
 
     @OneToOne(fetch = FetchType.EAGER, mappedBy = "member")
+    @JoinColumn(nullable = false)
     private JpaAuthInfo authInfo;
 
     public static JpaMember of(UUID id, String name, String phoneNumber, String email, Curriculum curriculum, int generation, String loginId, String credential){

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/repository/MemberJpaRepository.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/repository/MemberJpaRepository.java
@@ -2,9 +2,15 @@ package com.fisa.member.persistence.repository;
 
 import com.fisa.member.persistence.entity.JpaMember;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberJpaRepository extends JpaRepository<JpaMember, UUID> {
     List<JpaMember> findByName(String name);
+
+    @Query("SELECT jm FROM JpaMember jm WHERE jm.authInfo.loginId=:loginId")
+    Optional<JpaMember> findByLoginId(String loginId);
+
 }

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/repository/MemberJpaRepository.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/repository/MemberJpaRepository.java
@@ -1,0 +1,10 @@
+package com.fisa.member.persistence.repository;
+
+import com.fisa.member.persistence.entity.JpaMember;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberJpaRepository extends JpaRepository<JpaMember, UUID> {
+    List<JpaMember> findByName(String name);
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/repository/MemberRepositoryImpl.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/repository/MemberRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.fisa.member.persistence.repository;
+
+import com.fisa.member.application.model.Member;
+import com.fisa.member.application.model.MemberId;
+import com.fisa.member.application.model.auth.LoginId;
+import com.fisa.member.application.model.profile.MemberName;
+import com.fisa.member.application.repository.MemberRepository;
+import com.fisa.member.persistence.entity.JpaAuthInfo;
+import com.fisa.member.persistence.entity.JpaMember;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepository {
+
+    private final MemberJpaRepository jpaRepository;
+
+    @Override
+    public List<Member> findByName(MemberName name) {
+        return jpaRepository.findByName(name.getName())
+                .stream().map(this::toModel).toList();
+    }
+
+    @Override
+    public Member findById(MemberId id) {
+        return jpaRepository.findById(id.getId())
+                .map(this::toModel)
+                .orElseThrow(() -> new IllegalArgumentException("Member Not Found : %s".formatted(id.getId())));
+    }
+
+    @Override
+    public Member findByLoginId(LoginId loginId) {
+        return null;
+    }
+
+    @Override
+    public void save(Member member) {
+
+    }
+
+    private Member toModel(JpaMember jpaMember){
+        JpaAuthInfo authInfo = jpaMember.getAuthInfo();
+        return Member.load(jpaMember.getId(), jpaMember.getName(), jpaMember.getPhoneNumber(), jpaMember.getGeneration(),
+                jpaMember.getEmail(), jpaMember.getCurriculum(), authInfo.getLoginId(), authInfo.getCredential());
+    }
+}

--- a/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/repository/MemberRepositoryImpl.java
+++ b/FISA-Authorization-Server/src/main/java/com/fisa/member/persistence/repository/MemberRepositoryImpl.java
@@ -19,30 +19,45 @@ public class MemberRepositoryImpl implements MemberRepository {
 
     @Override
     public List<Member> findByName(MemberName name) {
-        return jpaRepository.findByName(name.getName())
+        return jpaRepository.findByName(name.getValue())
                 .stream().map(this::toModel).toList();
     }
 
     @Override
     public Member findById(MemberId id) {
-        return jpaRepository.findById(id.getId())
+        return jpaRepository.findById(id.getValue())
                 .map(this::toModel)
-                .orElseThrow(() -> new IllegalArgumentException("Member Not Found : %s".formatted(id.getId())));
+                .orElseThrow(() -> new IllegalArgumentException("Member Not Found : %s".formatted(id.getValue())));
     }
 
     @Override
     public Member findByLoginId(LoginId loginId) {
-        return null;
+        return jpaRepository.findByLoginId(loginId.getValue())
+                .map(this::toModel)
+                .orElseThrow(() -> new IllegalArgumentException("Member Not Found (loginId) : %s".formatted(loginId.getValue())));
     }
 
     @Override
     public void save(Member member) {
-
+        jpaRepository.save(toEntity(member));
     }
 
     private Member toModel(JpaMember jpaMember){
         JpaAuthInfo authInfo = jpaMember.getAuthInfo();
         return Member.load(jpaMember.getId(), jpaMember.getName(), jpaMember.getPhoneNumber(), jpaMember.getGeneration(),
                 jpaMember.getEmail(), jpaMember.getCurriculum(), authInfo.getLoginId(), authInfo.getCredential());
+    }
+
+    private JpaMember toEntity(Member member){
+        return JpaMember.of(
+                member.getId().getValue(),
+                member.getName().getValue(),
+                member.getPhoneNumber().getValue(),
+                member.getEmail().getValue(),
+                member.getCurriculum(),
+                member.getGeneration(),
+                member.getAuthInfo().getLoginId().getValue(),
+                member.getAuthInfo().getCredential().getValue()
+        );
     }
 }


### PR DESCRIPTION
closes #3 

## 도메인 레이어의 Member
- 도메인 계층의 Member 를 정의하였고, Member 가지는 상태,속성들을 VO로 구현하였습니다.
- 도메인 레이어에서 데이터 저장소에 접근할 때 사용하는 Repository도 정의 및 구현하였습니다.

## 기타
- 잘못된 패키지 경로를 import 하는 구문을 삭제하였습니다.
- 인증/인가 부분에서 사용자의 Id를 뜻하는 필드명을 전부 `userId` -> `memberId` 로 변경하였습니다.